### PR TITLE
Optimize with `thread_rng().gen::<u128>()` from `try_fill`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -47,6 +47,24 @@ impl Timeflake {
         Self::from_values(time, None)
     }
 
+    #[cfg(all(
+        feature = "std",
+        not(target_arch = "wasm32"),
+        not(target_arch = "asmjs")
+    ))]
+    pub fn from_values(
+        timestamp: Duration,
+        random_val: Option<u128>,
+    ) -> Result<Timeflake, TimeflakeError> {
+        let random = match random_val {
+            Some(x) => x,
+            None => thread_rng().gen::<u128>(),
+        };
+
+        Ok(Self { timestamp, random })
+    }
+
+    #[cfg(any(not(feature = "std"), target_arch = "wasm32", target_arch = "asmjs"))]
     pub fn from_values(
         timestamp: Duration,
         random_val: Option<u128>,


### PR DESCRIPTION
### Changes
- Separate some high performance ARCH case and wasm or some no-std case.
- Confirmed direct 128bit sized generation with modern architecture is awesome (modern x86_64 and ARMv8a with some SIMD)

### Story
While I were modifying to 64bit sized timeflake, found the module generate 80bit sized random number with `try_fill`.
I think generate 128bit at once would be better.
Thanks.