### PR TITLE
Reduce type conversion on Timeflake::as_u128(...)

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -87,8 +87,8 @@ impl Timeflake {
 
     pub fn as_u128(&self) -> u128 {
         let timeflake = self.random & 0x000000000000FFFFFFFFFFFFFFFFFFFF;
-        let timestamp_part = self.timestamp.as_millis() as u64;
-        timeflake | (timestamp_part as u128) << 80
+        let timestamp_part = self.timestamp.as_millis();
+        timeflake | timestamp_part << 80
     }
 
     pub fn get_uuid(&self) -> Uuid {


### PR DESCRIPTION
### Description
Seems there's no reason to convert timestamp as u64 than convert to u128.
Since the ret is u128.
Also tested this with `cargo test`.

### Changes.
- Remove 2 times of type conversion on code.

### Story
Found above issue while port to 64bit sized version.